### PR TITLE
Update the display format of file types

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,9 +47,7 @@ py -m pip install "aftviewer[all] @ git+https://github.com/MeF0504/aftviewer"
 
 ## Usage
 ```bash
-usage: aftviewer [-h] [--version]
-                 [-t {hdf5,pickle,numpy,np_pickle,tar,zip,sqlite3,raw_image,jupyter,xpm,stl,fits}]
-                 file
+usage: aftviewer [-h] [--version] [-t TYPE] file
 
 show the constitution of a file. Supported file types ... hdf5, pickle, numpy,
 np_pickle, tar, zip, sqlite3, raw_image, jupyter, xpm, stl, fits. To see the
@@ -61,9 +59,10 @@ positional arguments:
 options:
   -h, --help            show this help message and exit
   --version, -V         show program's version number and exit
-  -t {hdf5,pickle,numpy,np_pickle,tar,zip,sqlite3,raw_image,jupyter,xpm,stl,fits}, --type {hdf5,pickle,numpy,np_pickle,tar,zip,sqlite3,raw_image,jupyter,xpm,stl,fits}
-                        specify the file type. "aftviewer help -t TYPE" will
-                        show the detailed help.
+  -t TYPE, --type TYPE  specify the file type. Available types are hdf5,
+                        pickle, numpy, np_pickle, tar, zip, sqlite3,
+                        raw_image, jupyter, xpm, stl, fits. "aftviewer help -t
+                        TYPE" will show the detailed help.
 
 AFTViewer has some subcommands, 'aftviewer help -t TYPE' shows detailed help,
 'aftviewer update' run the update command of AFTViewer, 'aftviewer

--- a/aftviewer/cli/__init__.py
+++ b/aftviewer/cli/__init__.py
@@ -40,6 +40,7 @@ def get_args() -> Args:
                         version=f'%(prog)s {VERSION}')
     parser.add_argument('-t', '--type', dest='type',
                         help='specify the file type.'
+                        f' Available types are {", ".join(supported_type)}.'
                         ' "aftviewer help -t TYPE"'
                         ' will show the detailed help.')
     tmpargs, rems = parser.parse_known_args()
@@ -113,7 +114,9 @@ def update(branch: str) -> None:
 def main() -> None:
     args = get_args()
     if not (args.type is None or args.type in GLOBAL_CONF.types):
-        print_error(f'invalid file type: {args.type}')
+        supported_type = ', '.join(list(GLOBAL_CONF.types.keys()).copy())
+        print(f'Please specify the type from {supported_type}.')
+        print_error(f'invalid file type: {args.type}.')
         return
 
     if args.file == 'config_list':

--- a/aftviewer/cli/__init__.py
+++ b/aftviewer/cli/__init__.py
@@ -41,8 +41,7 @@ def get_args() -> Args:
     parser.add_argument('-t', '--type', dest='type',
                         help='specify the file type.'
                         ' "aftviewer help -t TYPE"'
-                        ' will show the detailed help.',
-                        choices=supported_type)
+                        ' will show the detailed help.')
     tmpargs, rems = parser.parse_known_args()
     if tmpargs.file == 'shell_completion':
         add_args_shell_cmp(parser)
@@ -113,6 +112,9 @@ def update(branch: str) -> None:
 
 def main() -> None:
     args = get_args()
+    if not (args.type is None or args.type in GLOBAL_CONF.types):
+        print_error(f'invalid file type: {args.type}')
+        return
 
     if args.file == 'config_list':
         show_opts()

--- a/aftviewer/core/__version__.py
+++ b/aftviewer/core/__version__.py
@@ -1,1 +1,1 @@
-VERSION = "3.6.3"
+VERSION = "3.6.4"


### PR DESCRIPTION
Since the number of --type options was increased, the help message became confusing. 